### PR TITLE
refactored to allow for customizing oci profile in .env file

### DIFF
--- a/config/sample_.env
+++ b/config/sample_.env
@@ -1,3 +1,7 @@
+# --- OCI API Key Configuration ---------
+OCI_CONFIG_FILE="~/.oci/config"
+OCI_PROFILE="DEFAULT"
+
 # ─── OCI RAG AGent Configuration --------
 AGENT_ID="ocid1.genaiagent.oc1.us-chicago-1...."
 AGENT_EP_ID="ocid1.genaiagentendpoint....."

--- a/src/agent_teams/orderxhub/orderx.py
+++ b/src/agent_teams/orderxhub/orderx.py
@@ -15,6 +15,8 @@ PROJECT_ROOT = THIS_DIR.parent.parent.parent
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_EP_ID = os.getenv("AGENT_EP_ID")
 AGENT_SERVICE_EP = os.getenv("AGENT_SERVICE_EP")
 AGENT_KB_ID = os.getenv("AGENT_KB_ID")
@@ -29,7 +31,8 @@ def agent_flow_order():
     # A shared client for all agents
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region=AGENT_REGION
     )
 

--- a/src/agents/agent_image2text.py
+++ b/src/agents/agent_image2text.py
@@ -14,6 +14,8 @@ PROJECT_ROOT = THIS_DIR.parent.parent.parent
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_EP_ID = os.getenv("AGENT_EP_ID")
 AGENT_SERVICE_EP = os.getenv("AGENT_SERVICE_EP")
 AGENT_KB_ID = os.getenv("AGENT_KB_ID")
@@ -27,7 +29,8 @@ def agent_flow_image2text():
 
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region=AGENT_REGION
     )
 

--- a/src/agents/getinsights.py
+++ b/src/agents/getinsights.py
@@ -17,6 +17,8 @@ PROJECT_ROOT = THIS_DIR.parent.parent.parent
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_EP_ID = os.getenv("AGENT_EP_ID")
 AGENT_REGION = os.getenv("AGENT_REGION")
 
@@ -34,7 +36,8 @@ async def agent_flow(input_message:str):
 
         client = AgentClient(
             auth_type="api_key",
-            profile="DEFAULT",
+            config=OCI_CONFIG_FILE,
+            profile=OCI_PROFILE,
             region=AGENT_REGION
         )
 

--- a/src/agents/taxagent.py
+++ b/src/agents/taxagent.py
@@ -16,6 +16,8 @@ PROJECT_ROOT = THIS_DIR.parent.parent.parent
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_EP_ID = os.getenv("AGENT_EP_ID")
 AGENT_SERVICE_EP = os.getenv("AGENT_SERVICE_EP")
 AGENT_KB_ID = os.getenv("AGENT_KB_ID")
@@ -29,7 +31,8 @@ def agent_flow():
 
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region=AGENT_REGION
     )
 

--- a/src/examples/calculator_multi_turns.py
+++ b/src/examples/calculator_multi_turns.py
@@ -13,6 +13,8 @@ PROJECT_ROOT = THIS_DIR.parent.parent.parent
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_EP_ID = os.getenv("AGENT_EP_ID")
 AGENT_SERVICE_EP = os.getenv("AGENT_SERVICE_EP")
 AGENT_KB_ID = os.getenv("AGENT_KB_ID")
@@ -26,7 +28,8 @@ def agent_flow():
 
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region="us-chicago-1"
     )
 

--- a/src/examples/delete_tools.py
+++ b/src/examples/delete_tools.py
@@ -13,6 +13,8 @@ PROJECT_ROOT = THIS_DIR.parent.parent.parent
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_ID = os.getenv("AGENT_ID")
 AGENT_REGION = os.getenv("AGENT_REGION")
 AGENT_COMPARTMENT_ID = os.getenv("AGENT_COMPARTMENT_ID")
@@ -22,7 +24,8 @@ def delete_tools():
     # Create a client with your authentication details
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region=AGENT_REGION
     )
 

--- a/src/examples/multi_agent_collab.py
+++ b/src/examples/multi_agent_collab.py
@@ -14,6 +14,8 @@ print(PROJECT_ROOT)
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_ID = os.getenv("AGENT_ID")
 AGENT_EP_ID = os.getenv("AGENT_EP_ID")
 AGENT_REGION = os.getenv("AGENT_REGION")
@@ -42,7 +44,8 @@ def main():
     # Create a client with your authentication details
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region=AGENT_REGION
     )
 

--- a/src/examples/multi_tools.py
+++ b/src/examples/multi_tools.py
@@ -15,6 +15,8 @@ PROJECT_ROOT = THIS_DIR.parent.parent.parent
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_EP_ID = os.getenv("AGENT_EP_ID")
 AGENT_SERVICE_EP = os.getenv("AGENT_SERVICE_EP")
 AGENT_KB_ID = os.getenv("AGENT_KB_ID")
@@ -31,7 +33,8 @@ def main():
 
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region="us-chicago-1"
     )
 

--- a/src/examples/test_setup.py
+++ b/src/examples/test_setup.py
@@ -13,6 +13,8 @@ print(PROJECT_ROOT)
 load_dotenv(PROJECT_ROOT / "config/.env")  # expects OCI_ vars in .env
 
 # Set up the OCI GenAI Agents endpoint configuration
+OCI_CONFIG_FILE = os.getenv("OCI_CONFIG_FILE")
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 AGENT_ID = os.getenv("AGENT_ID")
 AGENT_EP_ID = os.getenv("AGENT_EP_ID")
 AGENT_REGION = os.getenv("AGENT_REGION")
@@ -40,7 +42,8 @@ def list_tools():
     # Create a client with your authentication details
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region=AGENT_REGION
     )
 
@@ -60,7 +63,8 @@ def main():
     # Replace the auth_type with your desired authentication method.
     client = AgentClient(
         auth_type="api_key",
-        profile="DEFAULT",
+        config=OCI_CONFIG_FILE,
+        profile=OCI_PROFILE,
         region=AGENT_REGION,
     )
 

--- a/src/llm/oci_embedding_model.py
+++ b/src/llm/oci_embedding_model.py
@@ -19,7 +19,7 @@ ENDPOINT       = os.getenv("OCI_GENAI_ENDPOINT")
 MODEL_ID       = os.getenv("OCI_EMBEDDING_MODEL")
 PROVIDER       = os.getenv("PROVIDER")
 AUTH_TYPE      = "API_KEY"
-CONFIG_PROFILE = "DEFAULT"
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 
 
 def initialize_embedding_model():
@@ -30,7 +30,8 @@ def initialize_embedding_model():
   truncate="NONE",
   compartment_id=COMPARTMENT_ID,
   auth_type=AUTH_TYPE,
-  auth_profile=CONFIG_PROFILE
+
+  auth_profile=OCI_PROFILE
 )
 
 def test():

--- a/src/llm/oci_genai.py
+++ b/src/llm/oci_genai.py
@@ -19,7 +19,7 @@ ENDPOINT       = os.getenv("OCI_GENAI_ENDPOINT")
 MODEL_ID       = os.getenv("OCI_GENAI_MODEL_ID")
 PROVIDER       = os.getenv("PROVIDER")
 AUTH_TYPE      = "API_KEY"
-CONFIG_PROFILE = "DEFAULT"
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 
 
 def initialize_llm():
@@ -34,7 +34,7 @@ def initialize_llm():
             # remove any unsupported kwargs like citation_types
         },
         auth_type=AUTH_TYPE,
-        auth_profile=CONFIG_PROFILE,
+        auth_profile=OCI_PROFILE,
     )
 
 def test():

--- a/src/llm/oci_genai_vision.py
+++ b/src/llm/oci_genai_vision.py
@@ -22,7 +22,7 @@ ENDPOINT       = os.getenv("OCI_VISION_GENAI_ENDPOINT")
 MODEL_ID       = os.getenv("OCI_VISION_GENAI_MODEL_ID")
 PROVIDER       = os.getenv("PROVIDER_VISION_")
 AUTH_TYPE      = "API_KEY"
-CONFIG_PROFILE = "DEFAULT"
+OCI_PROFILE = os.getenv("OCI_PROFILE")
 
 
 def initialize_vision_llm():
@@ -39,7 +39,7 @@ def initialize_vision_llm():
             "top_p": 0.75
         },
         auth_type=AUTH_TYPE,
-        auth_profile=CONFIG_PROFILE,
+        auth_profile=OCI_PROFILE,
     )
 
 # Load and encode your image (local file)


### PR DESCRIPTION
afaict all adk clients are updated to use the environment variables OCI_CONFIG_FILE and OCI_PROFILE to decide what config profile to use for authentication.

The langchain clients need some additional work:

adk_projects/src/llm/oci_ds_md.py
- not sure how best to refactor since it doesn't have any os imports yet

adk_projects/src/llm/oci_embedding_model.py, adk_projects/src/llm/oci_genai_vision.py, and adk_projects/src/llm/oci_genai.py
- langchain doesn't seem to support non-default config file names. Only updated the parameter for profile name

